### PR TITLE
Build compatibility with v6.4 (register_sysctl_paths)

### DIFF
--- a/gen_compat_def
+++ b/gen_compat_def
@@ -127,6 +127,8 @@ kbuild_test_symbol totalram_pages linux/mm.h
 kbuild_test_ref    totalram_pages linux/mm.h
 # b86c0e6429da ("netfilter: ecache: prepare for event notifier merge")
 kbuild_test_member nf_ct_event_notifier.ct_event net/netfilter/nf_conntrack_ecache.h
+# 6.4: 0199849acd07 ("sysctl: remove register_sysctl_paths()")
+kbuild_test_symbol register_sysctl_paths linux/sysctl.h
 
 echo "// End of compat_def.h"
 

--- a/ipt_NETFLOW.c
+++ b/ipt_NETFLOW.c
@@ -1929,16 +1929,18 @@ static ctl_table netflow_net_table[] = {
 	{ }
 };
 #else /* >= 2.6.25 */
+# ifdef HAVE_REGISTER_SYSCTL_PATHS
 static struct ctl_path netflow_sysctl_path[] = {
 	{
 		.procname = "net",
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+#  if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
 		.ctl_name = CTL_NET
-#endif
+#  endif
 	},
 	{ .procname = "netflow" },
 	{ }
 };
+# endif
 #endif /* 2.6.25 */
 #endif /* CONFIG_SYSCTL */
 
@@ -5666,7 +5668,11 @@ static int __init ipt_netflow_init(void)
 #endif
 						      );
 #else /* 2.6.25 */
+# ifdef HAVE_REGISTER_SYSCTL_PATHS
 	netflow_sysctl_header = register_sysctl_paths(netflow_sysctl_path, netflow_sysctl_table);
+# else
+	netflow_sysctl_header = register_sysctl("net/netflow", netflow_sysctl_table);
+# endif
 #endif
 	if (!netflow_sysctl_header) {
 		printk(KERN_ERR "netflow: can't register to sysctl\n");


### PR DESCRIPTION
'register_sysctl_paths' is missed from v6.4 due to 0199849acd07 ("sysctl: remove register_sysctl_paths()").